### PR TITLE
Recreate FastAPI bot structure with async ORM

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,6 @@
+"""Core application package."""
+
+from app.api import router as api_router
+from app.main import app
+
+__all__ = ["app", "api_router"]

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,0 +1,5 @@
+"""API package exposing FastAPI routers."""
+
+from app.api.routes import router
+
+__all__ = ["router"]

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,0 +1,74 @@
+"""FastAPI API routes for interacting with bot data."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import User
+from app.db.session import get_session
+
+router = APIRouter()
+
+
+class UserRead(BaseModel):
+    """Response schema representing a stored bot user."""
+
+    id: int
+    telegram_id: int
+    username: Optional[str]
+
+    class Config:
+        orm_mode = True
+
+
+class UserCreate(BaseModel):
+    """Payload schema for creating a new user."""
+
+    telegram_id: int
+    username: Optional[str] = None
+
+
+async def get_db_session() -> AsyncSession:
+    async with get_session() as session:
+        yield session
+
+
+@router.get("/users", response_model=List[UserRead])
+async def list_users(session: AsyncSession = Depends(get_db_session)) -> List[UserRead]:
+    """Return all users known to the bot."""
+
+    result = await session.execute(select(User))
+    users = result.scalars().all()
+    return [UserRead.model_validate(user) for user in users]
+
+
+@router.post("/users", response_model=UserRead, status_code=status.HTTP_201_CREATED)
+async def create_user(
+    payload: UserCreate, session: AsyncSession = Depends(get_db_session)
+) -> UserRead:
+    """Create a new user or return the existing one if present."""
+
+    result = await session.execute(select(User).where(User.telegram_id == payload.telegram_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        user = User(telegram_id=payload.telegram_id, username=payload.username)
+        session.add(user)
+        await session.commit()
+        await session.refresh(user)
+    return UserRead.model_validate(user)
+
+
+@router.get("/users/{telegram_id}", response_model=UserRead)
+async def get_user(telegram_id: int, session: AsyncSession = Depends(get_db_session)) -> UserRead:
+    """Retrieve a user by their Telegram identifier."""
+
+    result = await session.execute(select(User).where(User.telegram_id == telegram_id))
+    user = result.scalar_one_or_none()
+    if user is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
+    return UserRead.model_validate(user)

--- a/app/bot/__init__.py
+++ b/app/bot/__init__.py
@@ -1,0 +1,5 @@
+"""Telegram bot package."""
+
+from app.bot.handlers import router
+
+__all__ = ["router"]

--- a/app/bot/handlers.py
+++ b/app/bot/handlers.py
@@ -1,0 +1,64 @@
+"""Telegram bot handlers powered by aiogram."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from aiogram import F, Router
+from aiogram.types import Message
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import User
+from app.db.session import get_session
+
+router = Router(name="bot-handlers")
+
+
+async def get_or_create_user(
+    session: AsyncSession, telegram_id: int, username: Optional[str]
+) -> User:
+    """Retrieve a user by their Telegram identifier or create one if it does not exist."""
+
+    result = await session.execute(select(User).where(User.telegram_id == telegram_id))
+    user = result.scalar_one_or_none()
+
+    if user is not None:
+        return user
+
+    user = User(telegram_id=telegram_id, username=username)
+    session.add(user)
+
+    try:
+        await session.commit()
+    except IntegrityError:
+        await session.rollback()
+        result = await session.execute(select(User).where(User.telegram_id == telegram_id))
+        user = result.scalar_one()
+    else:
+        await session.refresh(user)
+
+    return user
+
+
+@router.message(F.text)
+async def echo_message(message: Message) -> None:
+    """Basic echo handler that stores user metadata before responding."""
+
+    if message.from_user is None:
+        await message.answer("Hello! I couldn't determine your Telegram user data.")
+        return
+
+    async with get_session() as session:
+        user = await get_or_create_user(
+            session=session,
+            telegram_id=message.from_user.id,
+            username=message.from_user.username,
+        )
+
+    greeting = (
+        f"Hello {user.username or 'there'}! You said: {message.text}."
+        " I have recorded your visit."
+    )
+    await message.answer(greeting)

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,6 @@
+"""Database utilities for the application."""
+
+from app.db.models import Base, User
+from app.db.session import engine, get_session
+
+__all__ = ["Base", "User", "engine", "get_session"]

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,0 +1,28 @@
+"""Database models for the dance bot application."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import BigInteger, DateTime, Integer, String
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+
+class Base(DeclarativeBase):
+    """Base declarative class for ORM models."""
+
+
+class User(Base):
+    """Represents a Telegram user interacting with the bot."""
+
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    telegram_id: Mapped[int] = mapped_column(BigInteger, unique=True, index=True)
+    username: Mapped[str | None] = mapped_column(String(length=255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc), nullable=False
+    )
+
+    def __repr__(self) -> str:
+        return f"User(id={self.id!r}, telegram_id={self.telegram_id!r})"

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,21 @@
+"""Database session and engine utilities."""
+
+from __future__ import annotations
+
+import os
+from contextlib import asynccontextmanager
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite+aiosqlite:///./app.db")
+
+engine = create_async_engine(DATABASE_URL, echo=False, future=True)
+async_session_factory = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+
+
+@asynccontextmanager
+async def get_session() -> AsyncSession:
+    """Provide an async database session."""
+
+    async with async_session_factory() as session:
+        yield session

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,18 @@
+"""Application entry point for FastAPI."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.api.routes import router as api_router
+
+app = FastAPI(title="Dance Bot API")
+
+app.include_router(api_router, prefix="/api")
+
+
+@app.get("/health")
+async def health_check() -> dict[str, str]:
+    """Simple health check endpoint."""
+
+    return {"status": "ok"}

--- a/manage.py
+++ b/manage.py
@@ -1,0 +1,25 @@
+"""Utility script for running one-off management tasks."""
+
+from __future__ import annotations
+
+import asyncio
+
+from app.db import Base
+from app.db.session import engine
+
+
+async def init_db() -> None:
+    """Create database tables defined by the ORM models."""
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+def main() -> None:
+    """Entry point for management commands."""
+
+    asyncio.run(init_db())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- rebuild the FastAPI and Telegram bot package structure with async SQLAlchemy models and sessions
- add async Telegram handlers that manage users directly through ORM helpers
- expose API routes, main application setup, and database management script without the old services layer

## Testing
- python -m compileall app manage.py

------
https://chatgpt.com/codex/tasks/task_e_68cfb77d8b748330a2975d7b36d1233e